### PR TITLE
Continue rendering form elements without a name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/coding-standard": "^12.0",
         "laminas/laminas-servicemanager": "^3.22.1",
         "maglnet/composer-require-checker": "^4.13.0",
-        "phpunit/phpunit": "^10.5.37",
+        "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.19.0",
         "squizlabs/php_codesniffer": "^3.10.3",
         "vimeo/psalm": "^5.26.1"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
-        "laminas/laminas-servicemanager": "^3.22.1",
+        "laminas/laminas-servicemanager": "^3.23.0",
         "maglnet/composer-require-checker": "^4.13.0",
         "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.19.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80538d28960e714254e8b8319a2a2ed1",
+    "content-hash": "fb299b95b573f253781a60f2db576825",
     "packages": [
         {
             "name": "gsteel/dot",
@@ -2647,16 +2647,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.37",
+            "version": "10.5.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c7cffa0efa2b70c22366523e6d804c9419eb2400"
+                "reference": "a86773b9e887a67bc53efa9da9ad6e3f2498c132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c7cffa0efa2b70c22366523e6d804c9419eb2400",
-                "reference": "c7cffa0efa2b70c22366523e6d804c9419eb2400",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a86773b9e887a67bc53efa9da9ad6e3f2498c132",
+                "reference": "a86773b9e887a67bc53efa9da9ad6e3f2498c132",
                 "shasum": ""
             },
             "require": {
@@ -2728,7 +2728,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.37"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.38"
             },
             "funding": [
                 {
@@ -2744,7 +2744,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-19T13:03:41+00:00"
+            "time": "2024-10-28T13:06:21+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb299b95b573f253781a60f2db576825",
+    "content-hash": "60840022ac0c15b000a7548de1489d5f",
     "packages": [
         {
             "name": "gsteel/dot",
@@ -505,21 +505,21 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.22.1",
+            "version": "3.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "de98d297d4743956a0558a6d71616979ff779328"
+                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/de98d297d4743956a0558a6d71616979ff779328",
-                "reference": "de98d297d4743956a0558a6d71616979ff779328",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a8640182b892b99767d54404d19c5c3b3699f79b",
+                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.17",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
@@ -536,15 +536,15 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "friendsofphp/proxy-manager-lts": "^1.0.14",
-                "laminas/laminas-code": "^4.10.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.18",
+                "laminas/laminas-code": "^4.14.0",
                 "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
-                "mikey179/vfsstream": "^1.6.11",
-                "phpbench/phpbench": "^1.2.9",
-                "phpunit/phpunit": "^10.4",
+                "mikey179/vfsstream": "^1.6.12",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.36",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.8.0"
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -591,7 +591,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-24T11:19:47+00:00"
+            "time": "2024-10-28T21:32:16+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/composer.lock
+++ b/composer.lock
@@ -1819,16 +1819,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -1867,7 +1867,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -1875,7 +1875,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2157,16 +2157,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.4.1",
+            "version": "5.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c"
+                "reference": "0c70d2c566e899666f367ab7b80986beb3581e6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/0c70d2c566e899666f367ab7b80986beb3581e6f",
+                "reference": "0c70d2c566e899666f367ab7b80986beb3581e6f",
                 "shasum": ""
             },
             "require": {
@@ -2179,13 +2179,13 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.5",
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "vimeo/psalm": "^5.13"
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -2215,29 +2215,29 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.4.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.5.1"
             },
-            "time": "2024-05-21T05:55:05+00:00"
+            "time": "2024-11-06T11:58:54+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d"
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
-                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18"
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
@@ -2273,9 +2273,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.9.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
             },
-            "time": "2024-11-03T20:11:34+00:00"
+            "time": "2024-11-09T15:12:26+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -3987,16 +3987,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.1.6",
+            "version": "v7.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "bb5192af6edc797cbab5c8e8ecfea2fe5f421e57"
+                "reference": "3284aafcac338b6e86fd955ee4d794cbe434151a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/bb5192af6edc797cbab5c8e8ecfea2fe5f421e57",
-                "reference": "bb5192af6edc797cbab5c8e8ecfea2fe5f421e57",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3284aafcac338b6e86fd955ee4d794cbe434151a",
+                "reference": "3284aafcac338b6e86fd955ee4d794cbe434151a",
                 "shasum": ""
             },
             "require": {
@@ -4060,7 +4060,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.1.6"
+                "source": "https://github.com/symfony/console/tree/v7.1.7"
             },
             "funding": [
                 {
@@ -4076,7 +4076,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-09T08:46:59+00:00"
+            "time": "2024-11-05T15:34:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/composer.lock
+++ b/composer.lock
@@ -178,16 +178,16 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.38.0",
+            "version": "2.39.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "3037168c2db8af3088aca8826bdf7e249fd24ce3"
+                "reference": "515f081cdbea90721bfbffdd15184564b256478e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/3037168c2db8af3088aca8826bdf7e249fd24ce3",
-                "reference": "3037168c2db8af3088aca8826bdf7e249fd24ce3",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/515f081cdbea90721bfbffdd15184564b256478e",
+                "reference": "515f081cdbea90721bfbffdd15184564b256478e",
                 "shasum": ""
             },
             "require": {
@@ -253,7 +253,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-17T20:43:05+00:00"
+            "time": "2024-10-31T21:18:49+00:00"
         },
         {
             "name": "laminas/laminas-form",
@@ -595,30 +595,30 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.19.0",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "6a192dd0882b514e45506f533b833b623b78fff3"
+                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/6a192dd0882b514e45506f533b833b623b78fff3",
-                "reference": "6a192dd0882b514e45506f533b833b623b78fff3",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/8974a1213be42c3e2f70b2c27b17f910291ab2f4",
+                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5",
-                "phpbench/phpbench": "^1.2.15",
-                "phpunit/phpunit": "^10.5.8",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.20.0"
+                "laminas/laminas-coding-standard": "^3.0",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "type": "library",
             "autoload": {
@@ -650,7 +650,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-01-19T12:39:49+00:00"
+            "time": "2024-10-29T13:46:07+00:00"
         },
         {
             "name": "laminas/laminas-validator",
@@ -2221,23 +2221,23 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.8.2",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c"
+                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/153ae662783729388a584b4361f2545e4d841e3c",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
+                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.13"
+                "phpstan/phpdoc-parser": "^1.18"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
@@ -2273,9 +2273,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.9.0"
             },
-            "time": "2024-02-23T11:10:43+00:00"
+            "time": "2024-11-03T20:11:34+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -3987,16 +3987,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.1.5",
+            "version": "v7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0fa539d12b3ccf068a722bbbffa07ca7079af9ee"
+                "reference": "bb5192af6edc797cbab5c8e8ecfea2fe5f421e57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0fa539d12b3ccf068a722bbbffa07ca7079af9ee",
-                "reference": "0fa539d12b3ccf068a722bbbffa07ca7079af9ee",
+                "url": "https://api.github.com/repos/symfony/console/zipball/bb5192af6edc797cbab5c8e8ecfea2fe5f421e57",
+                "reference": "bb5192af6edc797cbab5c8e8ecfea2fe5f421e57",
                 "shasum": ""
             },
             "require": {
@@ -4060,7 +4060,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.1.5"
+                "source": "https://github.com/symfony/console/tree/v7.1.6"
             },
             "funding": [
                 {
@@ -4076,7 +4076,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:28:38+00:00"
+            "time": "2024-10-09T08:46:59+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4147,16 +4147,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.1.5",
+            "version": "v7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "61fe0566189bf32e8cfee78335d8776f64a66f5a"
+                "reference": "c835867b3c62bb05c7fe3d637c871c7ae52024d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/61fe0566189bf32e8cfee78335d8776f64a66f5a",
-                "reference": "61fe0566189bf32e8cfee78335d8776f64a66f5a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c835867b3c62bb05c7fe3d637c871c7ae52024d4",
+                "reference": "c835867b3c62bb05c7fe3d637c871c7ae52024d4",
                 "shasum": ""
             },
             "require": {
@@ -4193,7 +4193,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.1.5"
+                "source": "https://github.com/symfony/filesystem/tree/v7.1.6"
             },
             "funding": [
                 {
@@ -4209,7 +4209,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-17T09:16:35+00:00"
+            "time": "2024-10-25T15:11:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4614,16 +4614,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.5",
+            "version": "v7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d66f9c343fa894ec2037cc928381df90a7ad4306"
+                "reference": "61b72d66bf96c360a727ae6232df5ac83c71f626"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d66f9c343fa894ec2037cc928381df90a7ad4306",
-                "reference": "d66f9c343fa894ec2037cc928381df90a7ad4306",
+                "url": "https://api.github.com/repos/symfony/string/zipball/61b72d66bf96c360a727ae6232df5ac83c71f626",
+                "reference": "61b72d66bf96c360a727ae6232df5ac83c71f626",
                 "shasum": ""
             },
             "require": {
@@ -4681,7 +4681,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.5"
+                "source": "https://github.com/symfony/string/tree/v7.1.6"
             },
             "funding": [
                 {
@@ -4697,7 +4697,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:28:38+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4911,13 +4911,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.2 || ~8.3 || ~8.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2.99"
     },

--- a/src/Plugin/CheckBox.php
+++ b/src/Plugin/CheckBox.php
@@ -6,7 +6,6 @@ namespace Looker\Form\Plugin;
 
 use Laminas\Form\Element\Checkbox as CheckboxElement;
 use Looker\Form\HTML\InputAttribute;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HtmlAttributes;
 use Looker\Value\Doctype;
@@ -33,12 +32,12 @@ final readonly class CheckBox
     ): string {
         $name = $attributes['name'] ?? null;
         $name = $element->getName() ?? $name;
-        if (! is_string($name) || $name === '') {
-            throw FormElementsMustBeNamed::with($element);
+        unset($attributes['name']);
+        if (is_string($name) && $name !== '') {
+            $attributes['name'] = $name;
         }
 
         $attributes          = array_merge($element->getAttributes(), $attributes);
-        $attributes['name']  = $name;
         $attributes['type']  = 'checkbox';
         $attributes['value'] = $element->getCheckedValue();
         $closingBracket      = $this->doctype->isXhtml() ? ' />' : '>';

--- a/src/Plugin/Exception/FormElementsMustBeNamed.php
+++ b/src/Plugin/Exception/FormElementsMustBeNamed.php
@@ -5,20 +5,9 @@ declare(strict_types=1);
 namespace Looker\Form\Plugin\Exception;
 
 use InvalidArgumentException;
-use Laminas\Form\ElementInterface;
-
-use function sprintf;
 
 final class FormElementsMustBeNamed extends InvalidArgumentException
 {
-    public static function with(ElementInterface $element): self
-    {
-        return new self(sprintf(
-            'Received a form element of type "%s" that does not have a name, nor any name attribute provided',
-            $element::class,
-        ));
-    }
-
     public static function forLabelling(): self
     {
         return new self(

--- a/src/Plugin/FormInput.php
+++ b/src/Plugin/FormInput.php
@@ -8,7 +8,6 @@ use Laminas\Form\Element;
 use Laminas\Form\Element\Password;
 use Laminas\Form\ElementInterface;
 use Looker\Form\HTML\InputAttribute;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\Form\Plugin\Exception\InvalidElementType;
 use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HtmlAttributes;
@@ -59,12 +58,12 @@ final readonly class FormInput
 
         $name = $attributes['name'] ?? null;
         $name = $element->getName() ?? $name;
-        if (! is_string($name) || $name === '') {
-            throw FormElementsMustBeNamed::with($element);
+        unset($attributes['name']);
+        if (is_string($name) && $name !== '') {
+            $attributes['name'] = $name;
         }
 
         $attributes          = array_merge($element->getAttributes(), $attributes);
-        $attributes['name']  = $name;
         $attributes['type']  = self::TYPE_MAP[$elementClass];
         $attributes['value'] = (string) $element->getValue();
         if ($element instanceof Password) {

--- a/src/Plugin/MultiCheckBox.php
+++ b/src/Plugin/MultiCheckBox.php
@@ -9,7 +9,6 @@ use Laminas\Form\Element\MultiCheckbox as MultiCheckboxElement;
 use Laminas\Form\Element\Radio;
 use Looker\Form\HTML\InputAttribute;
 use Looker\Form\HTML\LabelAttribute;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\Form\Plugin\Exception\MultiCheckBoxCannotBeRendered;
 use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HtmlAttributes;
@@ -28,7 +27,6 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_scalar;
-use function is_string;
 use function sprintf;
 use function str_ends_with;
 
@@ -59,11 +57,6 @@ final readonly class MultiCheckBox
         MultiCheckboxElement|Radio $element,
         string $labelPosition = self::APPEND,
     ): string {
-        $name = $element->getName();
-        if (! is_string($name) || $name === '') {
-            throw FormElementsMustBeNamed::with($element);
-        }
-
         $markup = [$this->renderOptions($element, $labelPosition)];
 
         if ($element->useHiddenElement()) {

--- a/src/Plugin/Select.php
+++ b/src/Plugin/Select.php
@@ -7,7 +7,6 @@ namespace Looker\Form\Plugin;
 use Laminas\Escaper\Escaper;
 use Laminas\Form\Element\Select as SelectElement;
 use Looker\Form\HTML\SelectAttribute;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\Form\Plugin\Exception\SelectElementCannotBeRendered;
 use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HtmlAttributes;
@@ -40,15 +39,14 @@ final readonly class Select
         $attributes = array_merge($element->getAttributes(), $attributes);
         $name       = $attributes['name'] ?? null;
         $name       = $element->getName() ?? $name;
-        if (! is_string($name) || $name === '') {
-            throw FormElementsMustBeNamed::with($element);
-        }
+        unset($attributes['name']);
+        if (is_string($name) && $name !== '') {
+            if ($element->isMultiple() && ! str_contains($name, '[]')) {
+                $name .= '[]';
+            }
 
-        if ($element->isMultiple() && ! str_contains($name, '[]')) {
-            $name .= '[]';
+            $attributes['name'] = $name;
         }
-
-        $attributes['name'] = $name;
 
         $attributes = ($this->invalidElementHandler)($element, $attributes);
 

--- a/src/Plugin/Textarea.php
+++ b/src/Plugin/Textarea.php
@@ -7,7 +7,6 @@ namespace Looker\Form\Plugin;
 use Laminas\Escaper\Escaper;
 use Laminas\Form\Element\Textarea as TextareaInput;
 use Looker\Form\HTML\TextareaAttribute;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HtmlAttributes;
 
@@ -30,8 +29,9 @@ final readonly class Textarea
         $attributes = array_merge($element->getAttributes(), $attributes);
         $name       = $attributes['name'] ?? null;
         $name       = $element->getName() ?? $name;
-        if (! is_string($name) || $name === '') {
-            throw FormElementsMustBeNamed::with($element);
+        unset($attributes['name']);
+        if (is_string($name) && $name !== '') {
+            $attributes['name'] = $name;
         }
 
         $attributes = ($this->invalidElementHandler)($element, $attributes);

--- a/test/Plugin/CheckBoxTest.php
+++ b/test/Plugin/CheckBoxTest.php
@@ -7,11 +7,12 @@ namespace Looker\Form\Test\Plugin;
 use Laminas\Escaper\Escaper;
 use Laminas\Form\Element\Checkbox as CheckboxElement;
 use Looker\Form\Plugin\CheckBox;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\Form\Plugin\InvalidElementAttributeHandler;
 use Looker\Plugin\HtmlAttributes;
 use Looker\Value\Doctype;
 use PHPUnit\Framework\TestCase;
+
+use const PHP_EOL;
 
 class CheckBoxTest extends TestCase
 {
@@ -54,11 +55,14 @@ class CheckBoxTest extends TestCase
         );
     }
 
-    public function testMissingElementNameIsExceptional(): void
+    public function testElementWithoutNameIsRendered(): void
     {
         $element = new CheckboxElement();
-        $this->expectException(FormElementsMustBeNamed::class);
-        $this->plugin->__invoke($element);
+        $markup  = $this->plugin->__invoke($element);
+        self::assertSame(
+            '<input type="hidden" value="0">' . PHP_EOL . '<input type="checkbox" value="1">',
+            $markup,
+        );
     }
 
     public function testThatNameTypeAndValueAreIgnoredInGivenAttributes(): void

--- a/test/Plugin/FormInputTest.php
+++ b/test/Plugin/FormInputTest.php
@@ -7,7 +7,6 @@ namespace Looker\Form\Test\Plugin;
 use Laminas\Escaper\Escaper;
 use Laminas\Form\Element;
 use Laminas\Form\ElementInterface;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\Form\Plugin\Exception\InvalidElementType;
 use Looker\Form\Plugin\FormInput;
 use Looker\Form\Plugin\InvalidElementAttributeHandler;
@@ -63,10 +62,11 @@ class FormInputTest extends TestCase
         );
     }
 
-    public function testThatAMissingNameIsExceptional(): void
+    public function testThatTheElementIsRenderedWithoutAName(): void
     {
-        $this->expectException(FormElementsMustBeNamed::class);
-        $this->helper->__invoke(new Element\Text());
+        $markup = $this->helper->__invoke(new Element\Text());
+
+        self::assertSame('<input type="text" value="">', $markup);
     }
 
     public function testThatFormInputOnlyAcceptsInputTypes(): void

--- a/test/Plugin/SelectTest.php
+++ b/test/Plugin/SelectTest.php
@@ -6,7 +6,6 @@ namespace Looker\Form\Test\Plugin;
 
 use Laminas\Escaper\Escaper;
 use Laminas\Form\Element\Select as SelectElement;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\Form\Plugin\Exception\SelectElementCannotBeRendered;
 use Looker\Form\Plugin\InvalidElementAttributeHandler;
 use Looker\Form\Plugin\Option;
@@ -207,11 +206,11 @@ class SelectTest extends TestCase
         $this->helper->__invoke($element);
     }
 
-    public function testThatAnElementWithoutANameIsExceptional(): void
+    public function testThatAnElementWithoutANameIsRendered(): void
     {
         $element = new SelectElement();
-        $this->expectException(FormElementsMustBeNamed::class);
-        $this->helper->__invoke($element);
+        $markup  = $this->helper->__invoke($element);
+        self::assertSame("<select >\n\n</select>", $markup);
     }
 
     public function testThatAnElementNameWillBeGivenSquareBracketsWhenMultiple(): void

--- a/test/Plugin/TextareaTest.php
+++ b/test/Plugin/TextareaTest.php
@@ -6,7 +6,6 @@ namespace Looker\Form\Test\Plugin;
 
 use Laminas\Escaper\Escaper;
 use Laminas\Form\Element\Textarea as Element;
-use Looker\Form\Plugin\Exception\FormElementsMustBeNamed;
 use Looker\Form\Plugin\InvalidElementAttributeHandler;
 use Looker\Form\Plugin\Textarea;
 use Looker\Plugin\HtmlAttributes;
@@ -100,11 +99,11 @@ class TextareaTest extends TestCase
         );
     }
 
-    public function testANameIsRequired(): void
+    public function testTheElementIsRenderedWithoutAName(): void
     {
         $element = new Element();
-        $this->expectException(FormElementsMustBeNamed::class);
-        $this->helper->__invoke($element);
+        $markup  = $this->helper->__invoke($element);
+        self::assertSame('<textarea ></textarea>', $markup);
     }
 
     public function testValueIsEscaped(): void


### PR DESCRIPTION
The `name` attribute is _not_ required by the spec and there are all kinds of reasons why you may not want to include it.